### PR TITLE
Fix navigation, separate CSS, and add new pages (menu, phone, support)

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,65 @@
+body {
+    margin: 0;
+    font-family: 'Segoe UI', sans-serif;
+    background: #e0e0e0;
+}
+
+header {
+    background: #222;
+    padding: 20px 0;
+    display: flex;
+    justify-content: center;
+}
+
+nav a {
+    color: #fff;
+    text-decoration: none;
+    margin: 0 25px;
+    font-size: 20px;
+    display: inline-block;
+    animation: bounceIn 1s ease-in-out;
+    animation-delay: calc(var(--i) * 0.2s);
+    animation-fill-mode: both;
+}
+
+nav a:hover {
+    color: #ffd700;
+    transform: scale(1.1);
+}
+
+main {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+    padding: 50px;
+}
+
+.info-block {
+    background: #fff;
+    padding: 25px;
+    border-radius: 15px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+    transform-style: preserve-3d;
+    transition: transform 0.7s;
+    perspective: 800px;
+}
+
+.info-block:hover {
+    transform: rotateX(180deg);
+    background: #ffe;
+}
+
+
+@keyframes bounceIn {
+    0% {
+        opacity: 0;
+        transform: translateY(-40px);
+    }
+    60% {
+        opacity: 1;
+        transform: translateY(10px);
+    }
+    100% {
+        transform: translateY(0);
+    }
+}

--- a/menu.html
+++ b/menu.html
@@ -2,7 +2,7 @@
 <html lang="uk">
 <head>
     <meta charset="UTF-8">
-    <title>Сайт Микити Апостолова</title>
+    <title>Меню</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -17,14 +17,8 @@
 </header>
 
 <main>
-    <div class="info-block">
-        <h2>Ім'я</h2>
-        <p>Апостолов Микита</p>
-    </div>
-    <div class="info-block">
-        <h2>Група</h2>
-        <p>АІ-235</p>
-    </div>
+    <h2>Меню сайту</h2>
+    <p>Тут можна буде додати перелік сторінок або розділів.</p>
 </main>
 
 </body>

--- a/phone.html
+++ b/phone.html
@@ -2,7 +2,7 @@
 <html lang="uk">
 <head>
     <meta charset="UTF-8">
-    <title>Сайт Микити Апостолова</title>
+    <title>Телефон</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -17,14 +17,8 @@
 </header>
 
 <main>
-    <div class="info-block">
-        <h2>Ім'я</h2>
-        <p>Апостолов Микита</p>
-    </div>
-    <div class="info-block">
-        <h2>Група</h2>
-        <p>АІ-235</p>
-    </div>
+    <h2>Контактний телефон</h2>
+    <p>+380 63 649 40 78</p>
 </main>
 
 </body>

--- a/support.html
+++ b/support.html
@@ -2,7 +2,7 @@
 <html lang="uk">
 <head>
     <meta charset="UTF-8">
-    <title>Сайт Микити Апостолова</title>
+    <title>Підтримка онлайн</title>
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -17,14 +17,8 @@
 </header>
 
 <main>
-    <div class="info-block">
-        <h2>Ім'я</h2>
-        <p>Апостолов Микита</p>
-    </div>
-    <div class="info-block">
-        <h2>Група</h2>
-        <p>АІ-235</p>
-    </div>
+    <h2>Онлайн підтримка</h2>
+    <p>Apostolovnik1020@gmail.com</p>
 </main>
 
 </body>


### PR DESCRIPTION
## 🐞 Bug Report

**Problem description:**  
Navigation links in `index.html` were missing or incorrect, and all styles were written inline instead of in a separate CSS file.  
There were also no separate pages for **Menu**, **Phone**, and **Support**.  

**Steps to reproduce:**  
1. Open `index.html`.  
2. Try clicking on navigation links.  
3. Notice that they don’t lead anywhere.  
4. Observe that CSS styles are inline and not in a separate file.  

**Expected behavior:**  
- Navigation links should correctly lead to separate pages.  
- Styles should be moved into a dedicated CSS file.  
- Additional pages should exist with proper content.  

**Actual behavior:**  
- Navigation links did not work.  
- CSS styles were mixed with HTML.  
- Missing `menu.html`, `phone.html`, `support.html`.  

**Fix / Proposed solution:**  
- Added navigation links in `index.html`.  
- Moved styles into `css/style.css`.  
- Created new pages: `menu.html`, `phone.html`, `support.html`.  
- Added initial content to each page.  
- Tested locally — everything works correctly.  

---

## 🔀 Pull Request Summary

### Changes made:
- ✅ Added working navigation in `index.html`.  
- ✅ Separated CSS into `css/style.css`.  
- ✅ Created `menu.html`, `phone.html`, `support.html`.  
- ✅ Added initial content to new pages.  
- ✅ Verified locally — no issues found.  

---

📸 **Screenshots:**  
<img width="1191" height="237" alt="image" src="https://github.com/user-attachments/assets/b701f742-7c2e-43bb-ae4b-baa323d75076" />
<img width="1181" height="269" alt="image" src="https://github.com/user-attachments/assets/af7f98f3-1f7a-4220-a8d6-f4ccf123dade" />
<img width="1170" height="242" alt="image" src="https://github.com/user-attachments/assets/40b0a626-a21a-4b4a-8ff8-b952091c9808" />

